### PR TITLE
sony : pdx213 : remove non-existing attribute

### DIFF
--- a/Sony/pdx213/AndroidManifest.xml
+++ b/Sony/pdx213/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="me.phh.treble.overlay.sony.pdx213" android:versionCode="1" android:versionName="1.0">
-        <overlay android:targetPackage="android" android:requiredSystemPropertyName="ro.vendor.build.fingerprint" android:requiredSystemPropertyValue="+Sony/pdx213/pdx213*" android:priority="465" android:isStatic="true" />
+        <overlay android:targetPackage="android" android:requiredSystemPropertyName="ro.vendor.build.fingerprint" android:requiredSystemPropertyValue="+Sony/pdx213/pdx213*" android:priority="121" android:isStatic="true" />
 </manifest>

--- a/Sony/pdx213/res/values/config.xml
+++ b/Sony/pdx213/res/values/config.xml
@@ -68,14 +68,6 @@
         <item>255</item>  <!-- 4096 -->
     </integer-array>
 
-    <!-- List of biometric sensors on the device, in decreasing strength. Consumed by AuthService
-         when registering authenticators with BiometricService. Format must be ID:Modality:Strength,
-         where: IDs are unique per device, Modality as defined in BiometricAuthenticator.java,
-         and Strength as defined in BiometricManager.java -->
-    <string-array name="config_biometric_sensors" translatable="false" >
-        <item>0:2:15</item> <!-- ID0:Fingerprint:Strong -->
-    </string-array>
-
     <!-- Minimum screen brightness setting allowed by the power manager.
          The user is forbidden from setting the brightness below this level. -->
     <integer name="config_screenBrightnessSettingMinimum">2</integer>
@@ -215,9 +207,6 @@
     <!-- Wifi driver supports batched scan -->
     <bool translatable="false" name="config_wifi_batched_scan_supported">true</bool>
 
-    <!-- Indicate whether the SD card is accessible without removing the battery. -->
-    <bool name="config_batterySdCardAccessibility">true</bool>
-
     <!-- Indicate whether closing the lid causes the device to go to sleep and opening
          it causes the device to wake up.
          The default is false. -->
@@ -259,11 +248,6 @@
 
     <!-- Flag specifying whether or not IMS will use the ImsResolver dynamically -->
     <bool name="config_dynamic_bind_ims">true</bool>
-
-    <!-- Add the IWLan services for VoWiFi -->
-    <string name="config_wlan_data_service_package">vendor.qti.iwlan</string>
-    <string name="config_wlan_network_service_package">vendor.qti.iwlan</string>
-    <string name="config_qualified_networks_service_package">vendor.qti.iwlan</string>
 
 <!-- pdx213 base -->
 


### PR DESCRIPTION
hi Im ada12 in xda.

This pull request is for remove left non-existing attribute detected for phh-gsi.

overlay is fine exept that phh could pull it now.